### PR TITLE
チーム名のpathを変えないように、spanでくくった

### DIFF
--- a/ICPC-Standings-Colorizer.user.js
+++ b/ICPC-Standings-Colorizer.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         ICPC Japan Standings Colorizer
 // @namespace    https://github.com/riantkb/icpc_standing_colorizer
-// @version      0.5.4
+// @version      0.5.5
 // @description  ICPC Japan Standings Colorizer
 // @author       riantkb
 // @match        http://www.yamagula.ic.i.u-tokyo.ac.jp/*/standings.html
@@ -229,7 +229,7 @@ function firebaseapp() {
                     // var team_rating = convertFromRatingToSpan(team_dic[tname]['team_rating'])
                     var circle = generateTopcoderLikeCircle(team_dic[tname]['team_rating'])
                     var circle_span = `<span class='tooltip1'>${circle}<div class='description1'>${team_dic[tname]['team_rating']}</div></span>`;
-                    h = h.replace(tname, `${circle_span} ${tname}<br><small>${team_dic[tname]['members'].join(', ')}</small>`);
+                    h = h.replace(tname, `${circle_span} ${tname}<br><span><small>${team_dic[tname]['members'].join(', ')}</small></span>`);
                     e.innerHTML = h
                 }
             }


### PR DESCRIPTION
変更前は、登録してないチームは 
`div.team-col.team-name > span > small > span` 
登録しているチームは
`div.team-col.team-name > span > small:nth-child(5) > span > small`
というパスだったのを、small を span でくくることでパスを破壊しないようにした。